### PR TITLE
Improve parseing tagstring

### DIFF
--- a/Lib/test/test_tag_strings.py
+++ b/Lib/test/test_tag_strings.py
@@ -74,6 +74,18 @@ class TagStringTests(unittest.TestCase):
         self.assertEqual(conv, None)
         self.assertEqual(spec, None)
 
+    def test_escaped_backslash_n(self):
+        def tag(*args):
+            return args
+        res = tag"\\N{SPACE}"
+        self.assertEqual(len(res), 2)
+        self.assertEqual(res[0], r"\\N")
+        func, string, conv, spec = res[1]
+        SPACE = 42
+        self.assertEqual(func(), 42)
+        self.assertEqual(string, "SPACE")
+        self.assertEqual(conv, None)
+        self.assertEqual(spec, None)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1508,6 +1508,12 @@ expr_ty _PyPegen_decoded_from_token(Parser* p, Token* tok) {
         Py_DECREF(str);
         return NULL;
     }
+
+    Py_ssize_t size = PyBytes_Size(tok->bytes);
+    // Check unicode escape string \N{}
+    if (size >= 2 && bstr[size - 2] == '\\' && bstr[size - 1] == 'N') {
+        return _PyAST_Constant(str, NULL, tok->lineno, tok->col_offset, tok->end_lineno, tok->end_col_offset, p->arena);
+    }
     return _PyAST_Decoded(str, NULL, tok->lineno, tok->col_offset,
                            tok->end_lineno, tok->end_col_offset,
                            p->arena);


### PR DESCRIPTION
@lysnikolaou 
This fix is a PR that fixes an existing unittest I asked you about in the EuroPython sprint.

My guess is that you can probably improve code completion by adding unittests.
There are probably a few other edge cases that should be checked.

However, as I have limited knowledge of cpython and C, I would be grateful if you could review this small fix first.
If it is OK, I will add other test cases.

### Before
```python
~/PycharmProjects/cpython git:[tag-strings-rebased]
./python.exe Lib/test/test_tag_strings.py
.....E
======================================================================
ERROR: test_unicode_names (__main__.TagStringTests.test_unicode_names)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/koudai/PycharmProjects/cpython/Lib/test/test_tag_strings.py", line 67, in test_unicode_names
    res = tag"\N{SPACE}"
              ^^
UnicodeDecodeError: 'unicodeescape' codec can't decode bytes in position 0-1: malformed \N character escape

```

### After
```python
~/PycharmProjects/cpython git:[improve-parsing-tagstring]
./python.exe Lib/test/test_tag_strings.py
.......
----------------------------------------------------------------------
Ran 7 tests in 0.000s

OK
```

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
