### PR TITLE
PEP 750 bug and spec fix

### DIFF
--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -22,7 +22,7 @@ templateiter_next(templateiterobject *self)
     PyObject *item;
     if (self->from_strings) {
         item = PyIter_Next(self->stringsiter);
-        if (PyUnicode_GetLength(item) == 0) {
+        if (PyUnicode_GET_LENGTH(item) == 0) {
             Py_DECREF(item);
             item = PyIter_Next(self->interpolationsiter);
             self->from_strings = 0;

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -133,7 +133,7 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             if (!last_was_str) {
                 PyTuple_SET_ITEM(strings, stringsidx++, &_Py_STR(empty));
             }
-            PyTuple_SET_ITEM(interpolations, interpolationsidx, Py_NewRef(item));
+            PyTuple_SET_ITEM(interpolations, interpolationsidx++, Py_NewRef(item));
             last_was_str = 0;
         }
     }

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -22,15 +22,15 @@ templateiter_next(templateiterobject *self)
     PyObject *item;
     if (self->from_strings) {
         item = PyIter_Next(self->stringsiter);
+        self->from_strings = 0;
         if (PyUnicode_GET_LENGTH(item) == 0) {
             Py_SETREF(item, PyIter_Next(self->interpolationsiter));
-            // this gets flipped back to 1 below, so we'll iter strings next
-            self->from_strings = 0;
+            self->from_strings = 1;
         }
     } else {
         item = PyIter_Next(self->interpolationsiter);
+        self->from_strings = 1;
     }
-    self->from_strings = !self->from_strings;
     return item;
 }
 

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -24,6 +24,7 @@ templateiter_next(templateiterobject *self)
         item = PyIter_Next(self->stringsiter);
         if (PyUnicode_GET_LENGTH(item) == 0) {
             Py_SETREF(item, PyIter_Next(self->interpolationsiter));
+            // this gets flipped back to 1 below, so we'll iter strings next
             self->from_strings = 0;
         }
     } else {

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -23,8 +23,7 @@ templateiter_next(templateiterobject *self)
     if (self->from_strings) {
         item = PyIter_Next(self->stringsiter);
         if (PyUnicode_GET_LENGTH(item) == 0) {
-            Py_DECREF(item);
-            item = PyIter_Next(self->interpolationsiter);
+            Py_SETREF(item, PyIter_Next(self->interpolationsiter));
             self->from_strings = 0;
         }
     } else {

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -22,6 +22,11 @@ templateiter_next(templateiterobject *self)
     PyObject *item;
     if (self->from_strings) {
         item = PyIter_Next(self->stringsiter);
+        if (PyUnicode_GetLength(item) == 0) {
+            Py_DECREF(item);
+            item = PyIter_Next(self->interpolationsiter);
+            self->from_strings = 0;
+        }
     } else {
         item = PyIter_Next(self->interpolationsiter);
     }


### PR DESCRIPTION
- Fix a bug in `template_new()` where `interpolationsidx` wasn't being incremented, leading later to segfaults when accessing `Template.interpolations`
- Make sure `templateiter_next()` never returns empty strings, matching the updated PEP 750 spec for `__iter__()`

These changes pair nicely with [@wingysam's earlier PR](https://github.com/lysnikolaou/cpython/pull/57) &mdash; if it's easier, I also have a [branch that merges both](https://github.com/davepeck/tagstr-cpython/tree/dave/ts-iter-fix).
