### PR TITLE
Fix memory leak in template concat error handling

### DIFF
--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -204,11 +204,8 @@ template_from_strings_interpolations(PyTypeObject *type, PyObject *strings, PyOb
         return NULL;
     }
 
-    Py_NewRef(strings);
-    Py_NewRef(interpolations);
-
-    ((templateobject *) template)->strings = strings;
-    ((templateobject *) template)->interpolations = interpolations;
+    ((templateobject *) template)->strings = Py_NewRef(strings);
+    ((templateobject *) template)->interpolations = Py_NewRef(interpolations);
     return template;
 }
 

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -204,6 +204,9 @@ template_from_strings_interpolations(PyTypeObject *type, PyObject *strings, PyOb
         return NULL;
     }
 
+    Py_NewRef(strings);
+    Py_NewRef(interpolations);
+
     ((templateobject *) template)->strings = strings;
     ((templateobject *) template)->interpolations = interpolations;
     return template;
@@ -338,10 +341,9 @@ template_concat_templates(templateobject *self, templateobject *other)
     }
 
     PyObject *newtemplate = template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
-    if (newtemplate == NULL) {
-      Py_DECREF(newstrings);
-      Py_DECREF(newinterpolations);
-    }
+
+    Py_DECREF(newstrings);
+    Py_DECREF(newinterpolations);
 
     return newtemplate;
 }
@@ -361,10 +363,9 @@ template_concat_template_str(templateobject *self, PyObject *other)
     }
 
     PyObject *newtemplate = template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
-    if (newtemplate == NULL) {
-        Py_DECREF(newstrings);
-        Py_DECREF(newinterpolations);
-    }
+
+    Py_DECREF(newstrings);
+    Py_DECREF(newinterpolations);
 
     return newtemplate;
 }
@@ -384,10 +385,9 @@ template_concat_str_template(templateobject *self, PyObject *other)
     }
 
     PyObject *newtemplate = template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
-    if (newtemplate == NULL) {
-        Py_DECREF(newstrings);
-        Py_DECREF(newinterpolations);
-    }
+
+    Py_DECREF(newstrings);
+    Py_DECREF(newinterpolations);
 
     return newtemplate;
 }

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -337,7 +337,13 @@ template_concat_templates(templateobject *self, templateobject *other)
         return NULL;
     }
 
-    return template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
+    PyObject *newtemplate = template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
+    if (newtemplate == NULL) {
+      Py_DECREF(newstrings);
+      Py_DECREF(newinterpolations);
+    }
+
+    return newtemplate;
 }
 
 static PyObject *
@@ -354,7 +360,13 @@ template_concat_template_str(templateobject *self, PyObject *other)
         return NULL;
     }
 
-    return template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
+    PyObject *newtemplate = template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
+    if (newtemplate == NULL) {
+        Py_DECREF(newstrings);
+        Py_DECREF(newinterpolations);
+    }
+
+    return newtemplate;
 }
 
 static PyObject *
@@ -371,7 +383,13 @@ template_concat_str_template(templateobject *self, PyObject *other)
         return NULL;
     }
 
-    return template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
+    PyObject *newtemplate = template_from_strings_interpolations(Py_TYPE(self), newstrings, newinterpolations);
+    if (newtemplate == NULL) {
+        Py_DECREF(newstrings);
+        Py_DECREF(newinterpolations);
+    }
+
+    return newtemplate;
 }
 
 PyObject *


### PR DESCRIPTION
Fixes a memory leak when template concatenation fails (e.g., out of memory).
Ensures intermediate `strings` and `interpolations` tuples are now properly
released in `template_concat_*` functions.