### PR TITLE
Prospective fix for segfault in `_PyInterpolation_FromStackRefSteal`

### DIFF
--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -241,11 +241,19 @@ _PyInterpolation_FromStackRefSteal(_PyStackRef *values)
     PyTuple_SET_ITEM(args, 0, PyStackRef_AsPyObjectSteal(values[0]));
     PyTuple_SET_ITEM(args, 1, PyStackRef_AsPyObjectSteal(values[1]));
 
-    PyObject *conversion = PyStackRef_AsPyObjectSteal(values[2]);
-    PyTuple_SET_ITEM(args, 2, conversion ? conversion : Py_NewRef(Py_None));
+    if (PyStackRef_IsNull(values[2])) {
+        PyTuple_SET_ITEM(args, 2, Py_NewRef(Py_None));
+    } else {
+        PyObject *conversion = PyStackRef_AsPyObjectSteal(values[2]);
+        PyTuple_SET_ITEM(args, 2, conversion);
+    }
 
-    PyObject *format_spec = PyStackRef_AsPyObjectSteal(values[3]);
-    PyTuple_SET_ITEM(args, 3, format_spec ? format_spec : &_Py_STR(empty));
+    if (PyStackRef_IsNull(values[3])) {
+        PyTuple_SET_ITEM(args, 3, &_Py_STR(empty));
+    } else {
+        PyObject *format_spec = PyStackRef_AsPyObjectSteal(values[3]);
+        PyTuple_SET_ITEM(args, 3, format_spec);
+    }
 
     PyObject *interpolation = PyObject_CallObject((PyObject *) &_PyInterpolation_Type, args);
     Py_DECREF(args);


### PR DESCRIPTION
Currently, doing `t"{1}"` at the REPL will segfault. Doing `t"{1!r:foo}"` won't.

Just prior to merging cpython `main` (at `77822be`), all was well. After the merge (at `f3ba0fe`), crashes.

The crash is in `_PyInterpolation_FromStackRefSteal`, here:

```c
PyObject *conversion = PyStackRef_AsPyObjectSteal(values[2]);
```

Just prior to the merge of `main`, if you don't have a conversion, `values[2]` will be `0x0` and all will be fine. After the merge, `values[2]` will be `0x1` and we'll segfault.

I can see that a lot changed with `pycore_stackref.h` and related files in the `main` branch.  The definition of `_PyStackRef` even changed and moved to a new file (`pycore_structs.h`).

This PR adds checks for `PyStackRef_IsNull()` for `values[2]` and `values[3]`. I'm not entirely convinced it's the right thing to do, however, since I don't really understand how the core stack behavior changed. Even if we _do_ need a new check here, I'm not sure `PyStackRef_IsNull()` is the right one.