### PR TITLE
When debug specifier _and_ `format_spec` are present, use `!s` as the `conversion` default

### DIFF
--- a/Parser/action_helpers.c
+++ b/Parser/action_helpers.c
@@ -1467,9 +1467,10 @@ _get_interpolation_conversion(Parser *p, Token *debug, ResultTokenWithMetadata *
         Py_UCS4 first = PyUnicode_READ_CHAR(conversion_expr->v.Name.id, 0);
         return Py_SAFE_DOWNCAST(first, Py_UCS4, int);
     }
-    else if (debug && !format) {
-        /* If no conversion is specified, use !r for debug expressions */
-        return (int)'r';
+    else if (debug) {
+        // If no conversion and no format are specified, use !r for debug expressions;
+        // otherwise, if a format is specified, use !s.
+        return format ? (int)'s' : (int)'r';
     }
     return -1;
 }


### PR DESCRIPTION
Currently, `t"{1=:foo}".interpolations[0]` is `Interpolation(1, '1', None, 'foo')`. 

The [section of PEP750 on the debug specifier](https://peps.python.org/pep-0750/#support-for-the-debug-specifier) says it should be `Interpolation(1, '1', 's', 'foo')`.

Assuming we think the spec is right, here's a fix. (Otherwise, LMK and I'll fix the PEP.)

