### PR TITLE
t-strings: cosmetics

### DIFF
--- a/Include/internal/pycore_template.h
+++ b/Include/internal/pycore_template.h
@@ -9,8 +9,6 @@ extern "C" {
 #  error "this header requires Py_BUILD_CORE define"
 #endif
 
-#include "pycore_stackref.h"    // _PyStackRef
-
 extern PyTypeObject _PyTemplate_Type;
 extern PyTypeObject _PyTemplateIter_Type;
 

--- a/Lib/string/templatelib.py
+++ b/Lib/string/templatelib.py
@@ -1,3 +1,3 @@
 """Support for template string literals (t-strings)."""
 
-from _templatelib import Template, Interpolation
+from _templatelib import Interpolation, Template

--- a/Modules/_templatelibmodule.c
+++ b/Modules/_templatelibmodule.c
@@ -1,8 +1,8 @@
 /* interpreter-internal types for string.templatelib */
 
 #include "Python.h"
-#include "pycore_template.h"      // _PyTemplate_Type
 #include "pycore_interpolation.h" // _PyInterpolation_Type
+#include "pycore_template.h"      // _PyTemplate_Type
 
 static int
 _templatelib_exec(PyObject *m)

--- a/Modules/_templatelibmodule.c
+++ b/Modules/_templatelibmodule.c
@@ -26,7 +26,7 @@ static struct PyModuleDef_Slot _templatelib_slots[] = {
 static struct PyModuleDef _templatemodule = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_templatelib",
-    .m_doc = "Interpreter-internal types for t-string templates.",
+    .m_doc = "Interpreter types for template string literals (t-strings).",
     .m_size = 0,
     .m_slots = _templatelib_slots,
 };

--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -1,12 +1,7 @@
 /* t-string Interpolation object implementation */
+
 #include "Python.h"
-#include <stddef.h>
-
 #include "pycore_initconfig.h"      // _PyStatus_OK
-#include "pycore_stackref.h"        // _PyStackRef
-#include "pycore_global_objects.h"  // _Py_STR
-#include "pycore_runtime.h"         // _Py_STR
-
 #include "pycore_interpolation.h"
 
 static int

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -16,7 +16,6 @@
 #include "pycore_initconfig.h"    // _PyStatus_OK()
 #include "pycore_instruction_sequence.h" // _PyInstructionSequence_Type
 #include "pycore_interpolation.h" // _PyInterpolation_Type
-#include "pycore_hashtable.h"     // _Py_hashtable_new()
 #include "pycore_list.h"          // _PyList_DebugMallocStats()
 #include "pycore_long.h"          // _PyLong_GetZero()
 #include "pycore_memoryobject.h"  // _PyManagedBuffer_Type

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -26,7 +26,7 @@
 #include "pycore_pymem.h"         // _PyMem_IsPtrFreed()
 #include "pycore_pystate.h"       // _PyThreadState_GET()
 #include "pycore_symtable.h"      // PySTEntry_Type
-#include "pycore_template.h"      // _PyTemplate_Type
+#include "pycore_template.h"      // _PyTemplate_Type _PyTemplateIter_Type
 #include "pycore_tuple.h"         // _PyTuple_DebugMallocStats()
 #include "pycore_typeobject.h"    // _PyBufferWrapper_Type
 #include "pycore_typevarobject.h" // _PyTypeAlias_Type
@@ -2411,6 +2411,7 @@ static PyTypeObject* static_types[] = {
     &_PyHamt_CollisionNode_Type,
     &_PyHamt_Type,
     &_PyInstructionSequence_Type,
+    &_PyInterpolation_Type,
     &_PyLegacyEventHandler_Type,
     &_PyLineIterator,
     &_PyManagedBuffer_Type,
@@ -2420,6 +2421,8 @@ static PyTypeObject* static_types[] = {
     &_PyNone_Type,
     &_PyNotImplemented_Type,
     &_PyPositionsIterator,
+    &_PyTemplate_Type,
+    &_PyTemplateIter_Type,
     &_PyUnicodeASCIIIter_Type,
     &_PyUnion_Type,
 #ifdef _Py_TIER2
@@ -2430,9 +2433,6 @@ static PyTypeObject* static_types[] = {
     &_PyWeakref_RefType,
     &_PyTypeAlias_Type,
     &_PyNoDefault_Type,
-    &_PyInterpolation_Type,
-    &_PyTemplate_Type,
-    &_PyTemplateIter_Type,
 
     // subclasses: _PyTypes_FiniTypes() deallocates them before their base
     // class

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -1,13 +1,8 @@
 /* t-string Template object implementation */
+
 #include "Python.h"
-#include <stddef.h>
-
-#include "pycore_stackref.h"        // _PyStackRef
-#include "pycore_global_objects.h"  // _Py_STR
-#include "pycore_runtime.h"         // _Py_STR
-
+#include "pycore_interpolation.h" // _PyInterpolation_Check()
 #include "pycore_template.h"
-#include "pycore_interpolation.h"
 
 typedef struct {
     PyObject_HEAD

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -56,11 +56,11 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #include "pycore_pyhash.h"        // _Py_HashSecret_t
 #include "pycore_pylifecycle.h"   // _Py_SetFileSystemEncoding()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "pycore_template.h"      // _PyTemplate_Type
 #include "pycore_tuple.h"         // _PyTuple_FromArray()
 #include "pycore_ucnhash.h"       // _PyUnicode_Name_CAPI
 #include "pycore_unicodeobject.h" // struct _Py_unicode_state
 #include "pycore_unicodeobject_generated.h"  // _PyUnicode_InitStaticStrings()
-#include "pycore_template.h"      // _PyTemplate_Type
 
 #include "stringlib/eq.h"         // unicode_eq()
 #include <stddef.h>               // ptrdiff_t

--- a/Python/bytecodes.c
+++ b/Python/bytecodes.c
@@ -16,6 +16,7 @@
 #include "pycore_emscripten_signal.h"  // _Py_CHECK_EMSCRIPTEN_SIGNALS
 #include "pycore_function.h"
 #include "pycore_instruments.h"
+#include "pycore_interpolation.h" // _PyInterpolation_FromStackRefStealOnSuccess()
 #include "pycore_intrinsics.h"
 #include "pycore_long.h"          // _PyLong_GetZero()
 #include "pycore_moduleobject.h"  // PyModuleObject
@@ -30,10 +31,9 @@
 #include "pycore_setobject.h"     // _PySet_NextEntry()
 #include "pycore_sliceobject.h"   // _PyBuildSlice_ConsumeRefs
 #include "pycore_stackref.h"
+#include "pycore_template.h"      // _PyTemplate_From{List,Values}()
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "pycore_typeobject.h"    // _PySuper_Lookup()
-#include "pycore_interpolation.h"
-#include "pycore_template.h"
 
 #include "pycore_dict.h"
 #include "dictobject.h"

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -19,6 +19,7 @@
 #include "pycore_import.h"        // _PyImport_IsDefaultImportFunc()
 #include "pycore_instruments.h"
 #include "pycore_interpframe.h"   // _PyFrame_SetStackPointer()
+#include "pycore_interpolation.h" // _PyInterpolation_FromStackRefStealOnSuccess()
 #include "pycore_intrinsics.h"
 #include "pycore_jit.h"
 #include "pycore_list.h"          // _PyList_GetItemRef()
@@ -36,6 +37,7 @@
 #include "pycore_setobject.h"     // _PySet_Update()
 #include "pycore_sliceobject.h"   // _PyBuildSlice_ConsumeRefs
 #include "pycore_sysmodule.h"     // _PySys_GetOptionalAttrString()
+#include "pycore_template.h"      // _PyTemplate_From{List,Values}()
 #include "pycore_traceback.h"     // _PyTraceBack_FromFrame
 #include "pycore_tuple.h"         // _PyTuple_ITEMS()
 #include "pycore_uop_ids.h"       // Uops
@@ -46,8 +48,6 @@
 #include "pydtrace.h"
 #include "setobject.h"
 #include "pycore_stackref.h"
-#include "pycore_template.h"
-#include "pycore_interpolation.h"
 
 #include <stdbool.h>              // bool
 

--- a/Python/jit.c
+++ b/Python/jit.c
@@ -12,6 +12,7 @@
 #include "pycore_frame.h"
 #include "pycore_function.h"
 #include "pycore_interpframe.h"
+#include "pycore_interpolation.h"
 #include "pycore_intrinsics.h"
 #include "pycore_list.h"
 #include "pycore_long.h"
@@ -21,10 +22,9 @@
 #include "pycore_pyerrors.h"
 #include "pycore_setobject.h"
 #include "pycore_sliceobject.h"
+#include "pycore_template.h"
 #include "pycore_tuple.h"
 #include "pycore_unicodeobject.h"
-#include "pycore_interpolation.h"
-#include "pycore_template.h"
 
 #include "pycore_jit.h"
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -13,6 +13,7 @@
 #include "pycore_freelist.h"      // _PyObject_ClearFreeLists()
 #include "pycore_global_objects_fini_generated.h"  // _PyStaticObjects_CheckRefcnt()
 #include "pycore_initconfig.h"    // _PyStatus_OK()
+#include "pycore_interpolation.h" // _PyInterpolation_InitTypes()
 #include "pycore_long.h"          // _PyLong_InitTypes()
 #include "pycore_object.h"        // _PyDebug_PrintTotalRefs()
 #include "pycore_obmalloc.h"      // _PyMem_init_obmalloc()
@@ -33,7 +34,6 @@
 #include "pycore_uniqueid.h"      // _PyObject_FinalizeUniqueIdPool()
 #include "pycore_warnings.h"      // _PyWarnings_InitState()
 #include "pycore_weakref.h"       // _PyWeakref_GET_REF()
-#include "pycore_interpolation.h" // _PyInterpolation_InitTypes()
 
 #include "opcode.h"
 

--- a/Tools/jit/template.c
+++ b/Tools/jit/template.c
@@ -13,6 +13,7 @@
 #include "pycore_function.h"
 #include "pycore_genobject.h"
 #include "pycore_interpframe.h"
+#include "pycore_interpolation.h"
 #include "pycore_intrinsics.h"
 #include "pycore_jit.h"
 #include "pycore_list.h"
@@ -25,10 +26,9 @@
 #include "pycore_setobject.h"
 #include "pycore_sliceobject.h"
 #include "pycore_stackref.h"
+#include "pycore_template.h"
 #include "pycore_tuple.h"
 #include "pycore_unicodeobject.h"
-#include "pycore_interpolation.h"
-#include "pycore_template.h"
 
 #include "ceval_macros.h"
 


### PR DESCRIPTION
cc @lysnikolaou @davepeck

This is a series of four minor/cosmetic changes.

* Sort imports in `string.templatelib`
* Remove unused includes
* Sort includes, especially where the list they're in is already sorted. This is more questionable for the new files added in the `tstrings` branch, but I'd suggest it's useful for ease of future maintenence.
* Reword the `_templatelib` docstring, to better match `string.templatelib`
* Sort the list of types in the `object.c` `static_types` array (ignoring the most recent two unsorted entries).

A