### PR TITLE
t-strings: Add type-check macros

### DIFF
--- a/Include/internal/pycore_interpolation.h
+++ b/Include/internal/pycore_interpolation.h
@@ -13,6 +13,9 @@ extern "C" {
 
 extern PyTypeObject _PyInterpolation_Type;
 
+#define _PyInterpolation_Check(op) PyObject_TypeCheck((op), &_PyInterpolation_Type)
+#define _PyInterpolation_CheckExact(op) Py_IS_TYPE((op), &_PyInterpolation_Type)
+
 PyAPI_FUNC(PyObject *) _PyInterpolation_FromStackRefStealOnSuccess(_PyStackRef *values);
 
 extern PyStatus _PyInterpolation_InitTypes(PyInterpreterState *interp);

--- a/Include/internal/pycore_template.h
+++ b/Include/internal/pycore_template.h
@@ -14,6 +14,9 @@ extern "C" {
 extern PyTypeObject _PyTemplate_Type;
 extern PyTypeObject _PyTemplateIter_Type;
 
+#define _PyTemplate_Check(op) PyObject_TypeCheck((op), &_PyTemplate_Type)
+#define _PyTemplate_CheckExact(op) Py_IS_TYPE((op), &_PyTemplate_Type)
+
 extern PyObject *_PyTemplate_Concat(PyObject *self, PyObject *other);
 
 PyAPI_FUNC(PyObject *) _PyTemplate_FromValues(PyObject **values, Py_ssize_t n);

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -85,7 +85,7 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             }
             last_was_str = 1;
         }
-        else if (PyObject_TypeCheck(item, &_PyInterpolation_Type)) {
+        else if (_PyInterpolation_Check(item)) {
             if (!last_was_str) {
                 stringslen++;
             }
@@ -134,7 +134,7 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             }
             last_was_str = 1;
         }
-        else if (PyObject_TypeCheck(item, &_PyInterpolation_Type)) {
+        else if (_PyInterpolation_Check(item)) {
             if (!last_was_str) {
                 PyTuple_SET_ITEM(strings, stringsidx++, &_Py_STR(empty));
             }
@@ -397,14 +397,13 @@ template_concat_str_template(templateobject *self, PyObject *other)
 PyObject *
 _PyTemplate_Concat(PyObject *self, PyObject *other)
 {
-    if (PyObject_TypeCheck(self, &_PyTemplate_Type) &&
-            PyObject_TypeCheck(other, &_PyTemplate_Type)) {
+    if (_PyTemplate_Check(self) && _PyTemplate_Check(other)) {
         return template_concat_templates((templateobject *) self, (templateobject *) other);
     }
-    else if (PyObject_TypeCheck(self, &_PyTemplate_Type) && PyUnicode_Check(other)) {
+    else if ((_PyTemplate_Check(self)) && PyUnicode_Check(other)) {
         return template_concat_template_str((templateobject *) self, other);
     }
-    else if (PyUnicode_Check(self) && PyObject_TypeCheck(other, &_PyTemplate_Type)) {
+    else if (PyUnicode_Check(self) && (_PyTemplate_Check(other))) {
         return template_concat_str_template((templateobject *) other, self);
     }
     else {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11618,7 +11618,7 @@ PyUnicode_Concat(PyObject *left, PyObject *right)
         return NULL;
 
     if (!PyUnicode_Check(right)) {
-        if (PyObject_TypeCheck(right, &_PyTemplate_Type)) {
+        if (_PyTemplate_Check(right)) {
             // str + tstring is implemented in the tstring type
             return _PyTemplate_Concat(left, right);
         }


### PR DESCRIPTION
cc @lysnikolaou @davepeck

This adds convenience macros for type-checking, for both the interpolation and template types.

One question that I had during this work: should t-strings prohibit subclassing? This isn't relevant for f-strings, as they evaluate to `str`. For example, `types.UnionType` (recently merged with the Python implementation) prohibits it. I can't find mention of it in the PEP, though.

For example (note interpolation equality, #65 isn't yet merged):

```pycon
Python 3.14.0a7+ (heads/tstrings-dirty:45cae94a54b, Apr 17 2025, 01:26:44) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from string.templatelib import *
>>> spam = 1
>>> type(t'') is Template
True
>>> class T(Template): pass
... 
>>> list(t'lobster {spam}') == list(T('lobster ', Interpolation(spam, 'spam')))
True
```

This would mean changing to `CheckExact()` and removing `Py_TPFLAGS_BASETYPE` from the type declarations.

A