### PR TITLE
Add pickle support for tstrings

### DIFF
--- a/Lib/string/templatelib.py
+++ b/Lib/string/templatelib.py
@@ -1,3 +1,23 @@
 """Support for template string literals (t-strings)."""
 
 from _templatelib import Interpolation, Template
+
+__all__ = [
+    "Interpolation",
+    "Template",
+]
+
+def _template_unpickle(*args):
+    import itertools
+
+    if len(args) != 2:
+        raise ValueError('Template expects tuple of length 2 to unpickle')
+
+    strings, interpolations = args
+    parts = []
+    for string, interpolation in itertools.zip_longest(strings, interpolations):
+        if string is not None:
+            parts.append(string)
+        if interpolation is not None:
+            parts.append(interpolation)
+    return Template(*parts)

--- a/Lib/test/test_string/_support.py
+++ b/Lib/test/test_string/_support.py
@@ -2,7 +2,7 @@ import unittest
 from string.templatelib import Interpolation
 
 
-class TStringTestCase(unittest.TestCase):
+class TStringBaseCase:
     def assertTStringEqual(self, t, strings, interpolations):
         """Test template string literal equality.
 
@@ -23,7 +23,7 @@ class TStringTestCase(unittest.TestCase):
                 continue
 
             if len(exp) == 3:
-                self.assertEqual((i.value, i.expression, i.conversion),  exp)
+                self.assertEqual((i.value, i.expression, i.conversion), exp)
                 self.assertEqual(i.format_spec, '')
                 continue
 

--- a/Lib/test/test_tstring.py
+++ b/Lib/test/test_tstring.py
@@ -1,9 +1,9 @@
 import unittest
 
-from test.test_string._support import TStringTestCase, fstring
+from test.test_string._support import TStringBaseCase, fstring
 
 
-class TestTString(TStringTestCase):
+class TestTString(unittest.TestCase, TStringBaseCase):
     def test_string_representation(self):
         # Test __repr__
         t = t"Hello"

--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -125,6 +125,22 @@ static PyMemberDef interpolation_members[] = {
     {NULL}
 };
 
+static PyObject*
+interpolation_reduce(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    interpolationobject *self = (interpolationobject *)op;
+    return Py_BuildValue("(O(OOOO))", (PyObject *)Py_TYPE(op),
+                         self->value, self->expression,
+                         self->conversion, self->format_spec);
+}
+
+static PyMethodDef interpolation_methods[] = {
+    {"__reduce__", interpolation_reduce, METH_VARARGS,
+     PyDoc_STR("__reduce__() -> (cls, state)")},
+
+    {NULL,      NULL},
+};
+
 PyTypeObject _PyInterpolation_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "string.templatelib.Interpolation",
@@ -139,6 +155,7 @@ PyTypeObject _PyInterpolation_Type = {
     .tp_free = PyObject_GC_Del,
     .tp_repr = interpolation_repr,
     .tp_members = interpolation_members,
+    .tp_methods = interpolation_methods,
     .tp_traverse = interpolation_traverse,
 };
 

--- a/Objects/interpolationobject.c
+++ b/Objects/interpolationobject.c
@@ -128,7 +128,7 @@ static PyMemberDef interpolation_members[] = {
 static PyObject*
 interpolation_reduce(PyObject *op, PyObject *Py_UNUSED(dummy))
 {
-    interpolationobject *self = (interpolationobject *)op;
+    interpolationobject *self = interpolationobject_CAST(op);
     return Py_BuildValue("(O(OOOO))", (PyObject *)Py_TYPE(op),
                          self->value, self->expression,
                          self->conversion, self->format_spec);

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -114,7 +114,10 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             last_was_str = 0;
         }
         else {
-            PyErr_SetString(PyExc_TypeError, "Template.__new__ *args need to be of type 'str' or 'Interpolation'");
+            PyErr_Format(
+                PyExc_TypeError,
+                "Template.__new__ *args need to be of type 'str' or 'Interpolation', got %.200s",
+                Py_TYPE(item)->tp_name);
             return NULL;
         }
     }
@@ -418,12 +421,41 @@ static PyMemberDef template_members[] = {
 };
 
 static PyGetSetDef template_getset[] = {
-    {"values", template_values_get, NULL, "Values of interpolations", NULL},
+    {"values", template_values_get, NULL,
+     PyDoc_STR("Values of interpolations"), NULL},
     {NULL},
 };
 
 static PySequenceMethods template_as_sequence = {
     .sq_concat = _PyTemplate_Concat,
+};
+
+static PyObject*
+template_reduce(PyObject *op, PyObject *Py_UNUSED(dummy))
+{
+    PyObject *mod = PyImport_ImportModule("string.templatelib");
+    if (mod == NULL) {
+        return NULL;
+    }
+    PyObject *func = PyObject_GetAttrString(mod, "_template_unpickle");
+    Py_DECREF(mod);
+    if (func == NULL) {
+        return NULL;
+    }
+
+    templateobject *self = (templateobject *)op;
+    PyObject *result = Py_BuildValue("O(OO)",
+                                     func,
+                                     self->strings,
+                                     self->interpolations);
+
+    Py_DECREF(func);
+    return result;
+}
+
+static PyMethodDef template_methods[] = {
+    {"__reduce__", template_reduce, METH_NOARGS, NULL},
+    {NULL,      NULL},
 };
 
 PyTypeObject _PyTemplate_Type = {
@@ -441,6 +473,7 @@ PyTypeObject _PyTemplate_Type = {
     .tp_free = PyObject_GC_Del,
     .tp_repr = template_repr,
     .tp_members = template_members,
+    .tp_methods = template_methods,
     .tp_getset = template_getset,
     .tp_iter = template_iter,
     .tp_traverse = template_traverse,

--- a/Objects/templateobject.c
+++ b/Objects/templateobject.c
@@ -116,8 +116,8 @@ template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         else {
             PyErr_Format(
                 PyExc_TypeError,
-                "Template.__new__ *args need to be of type 'str' or 'Interpolation', got %.200s",
-                Py_TYPE(item)->tp_name);
+                "Template.__new__ *args need to be of type 'str' or 'Interpolation', got %T",
+                item);
             return NULL;
         }
     }
@@ -443,7 +443,7 @@ template_reduce(PyObject *op, PyObject *Py_UNUSED(dummy))
         return NULL;
     }
 
-    templateobject *self = (templateobject *)op;
+    templateobject *self = templateobject_CAST(op);
     PyObject *result = Py_BuildValue("O(OO)",
                                      func,
                                      self->strings,


### PR DESCRIPTION
I needed `_template_unpickle` because of how `Template` contructor works :(
I've also changed several other things:
- `TStringBaseCase` because it is better to have assertions as mixins, not exact test cases. Easier to compose
- `got %.200s` for the `TypeError` shows better error message